### PR TITLE
rearrange xml to make SAML compliant

### DIFF
--- a/CMMSAMLIdentityProvider/IdPLauncher.aspx
+++ b/CMMSAMLIdentityProvider/IdPLauncher.aspx
@@ -32,7 +32,7 @@
                         Service Provider URL
                     </td>
                     <td>
-                        <asp:TextBox ID="txtSPURL" runat="server" Text="https://ehr4-sso.testing.covermymeds.com/consume"></asp:TextBox>
+                        <asp:TextBox ID="txtSPURL" runat="server" Text="http://localhost:40728/ServiceProviderDefault.aspx"></asp:TextBox>
                     </td>
                 </tr>
                 <tr>
@@ -40,7 +40,7 @@
                         Target
                     </td>
                     <td>
-                        <asp:TextBox ID="txtTarget" runat="server" Text="https://ehr4-sso.testing.covermymeds.com/authenticated"></asp:TextBox>
+                        <asp:TextBox ID="txtTarget" runat="server" Text="http://localhost:2456/PromisedLand.aspx"></asp:TextBox>
                     </td>
                 </tr>
                 <tr>

--- a/CMMSAMLIdentityProvider/IdPLauncher.aspx
+++ b/CMMSAMLIdentityProvider/IdPLauncher.aspx
@@ -32,7 +32,7 @@
                         Service Provider URL
                     </td>
                     <td>
-                        <asp:TextBox ID="txtSPURL" runat="server" Text="http://localhost:40728/ServiceProviderDefault.aspx"></asp:TextBox>
+                        <asp:TextBox ID="txtSPURL" runat="server" Text="https://ehr4-sso.testing.covermymeds.com/consume"></asp:TextBox>
                     </td>
                 </tr>
                 <tr>
@@ -40,7 +40,7 @@
                         Target
                     </td>
                     <td>
-                        <asp:TextBox ID="txtTarget" runat="server" Text="http://localhost:2456/PromisedLand.aspx"></asp:TextBox>
+                        <asp:TextBox ID="txtTarget" runat="server" Text="https://ehr4-sso.testing.covermymeds.com/authenticated"></asp:TextBox>
                     </td>
                 </tr>
                 <tr>
@@ -54,7 +54,7 @@
                         Name ID
                     </td>
                     <td>
-                        <asp:TextBox ID="txtNameID" runat="server"></asp:TextBox>
+                        <asp:TextBox ID="txtNameID" runat="server" Text="hsimpson"></asp:TextBox>
                     </td>
                 </tr>
             </table>

--- a/CMMSAMLLibrary/CertificateUtility.cs
+++ b/CMMSAMLLibrary/CertificateUtility.cs
@@ -49,11 +49,10 @@ namespace CoverMyMeds.SAML.Library
             signedXML.AddReference(reference);
             signedXML.ComputeSignature();
 
-            XmlElement signature = signedXML.GetXml();
+			XmlElement signature = signedXML.GetXml();
 
-            XmlElement xeResponse = XMLSerializedSAMLResponse.DocumentElement;
-
-            xeResponse.AppendChild(signature);
+			XmlElement xeIssuer = xeAssertion.SelectSingleNode("saml:Issuer", ns) as XmlElement;
+			xeAssertion.InsertAfter(signature, xeIssuer);
         }
     }
 }

--- a/CMMSAMLLibrary/SAML20Assertion.cs
+++ b/CMMSAMLLibrary/SAML20Assertion.cs
@@ -50,7 +50,7 @@ namespace CoverMyMeds.SAML.Library
             // Create SAML Response object with a unique ID and correct version
             ResponseType response = new ResponseType()
             {
-                //ID = "_" + System.Guid.NewGuid().ToString(),
+                ID = "_" + System.Guid.NewGuid().ToString(),
                 Version = "2.0",
                 IssueInstant = System.DateTime.UtcNow,
                 Destination = Recipient.Trim(),
@@ -83,7 +83,7 @@ namespace CoverMyMeds.SAML.Library
             XmlDocument xmlResponse = new XmlDocument(); 
             xmlResponse.LoadXml(stringWriter.ToString());
 
-            // Set the namespace for prettire and more consistent XML
+            // Set the namespace for prettier and more consistent XML
             XmlNamespaceManager ns = new XmlNamespaceManager(xmlResponse.NameTable);
             ns.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
 
@@ -164,3 +164,5 @@ namespace CoverMyMeds.SAML.Library
 
     }
 }
+
+


### PR DESCRIPTION
It was recently discovered that the missing ID field and the order of the Signature section were resulting in non-compliant SAML, so this has been fixed.